### PR TITLE
feat: add multiline comment rule

### DIFF
--- a/eslint/core.js
+++ b/eslint/core.js
@@ -276,6 +276,7 @@ module.exports = {
             },
         ],
         'more/no-void-map': 'error',
+        'multiline-comment-style': ['error', 'starred-block'],
         'multiline-ternary': 'off',
         'newline-before-return': 'error',
         'newline-per-chained-call': [


### PR DESCRIPTION
BREAKING CHANGE: multiline comments now have to be formatted a specific way

https://eslint.org/docs/latest/rules/multiline-comment-style